### PR TITLE
fix: removed carriage return in beginning of templates

### DIFF
--- a/src/templates/reactTSTemplate.ts
+++ b/src/templates/reactTSTemplate.ts
@@ -1,5 +1,4 @@
-export default `
-import React, { FC } from 'react'
+export default `import React, { FC } from 'react'
 import { ComponentNameProps } from './ComponentName.types'
 
 const ComponentName: FC<ComponentNameProps> = () => {

--- a/src/templates/stylesTemplate.ts
+++ b/src/templates/stylesTemplate.ts
@@ -1,5 +1,4 @@
-export default `
-import { ComponentNameStyles } from './ComponentName.types'
+export default `import { ComponentNameStyles } from './ComponentName.types'
 
 export default (): ComponentNameStyles => ({
 

--- a/src/templates/typesTemplate.ts
+++ b/src/templates/typesTemplate.ts
@@ -1,5 +1,4 @@
-export default `
-export interface ComponentNameProps {
+export default `export interface ComponentNameProps {
 	
 }
 


### PR DESCRIPTION
Commands generated a carriage return at the beginning of each file. This pull request fixes that problem