### PR TITLE
fix: removed react from import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-utils-cli",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "CLI to create template React TS components",
 	"main": "index.ts",
 	"type": "module",

--- a/src/templates/reactTSTemplate.ts
+++ b/src/templates/reactTSTemplate.ts
@@ -1,4 +1,4 @@
-export default `import React, { FC } from 'react'
+export default `import { FC } from 'react'
 import { ComponentNameProps } from './ComponentName.types'
 
 const ComponentName: FC<ComponentNameProps> = () => {


### PR DESCRIPTION
As of React v17, we no longer need to write the React import statements