### PR TITLE
fix: fixed style template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-utils-cli",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "CLI to create template React TS components",
 	"main": "index.ts",
 	"type": "module",

--- a/src/templates/reactTSTemplate.ts
+++ b/src/templates/reactTSTemplate.ts
@@ -1,7 +1,9 @@
 export default `import { FC } from 'react'
+import makeStyles from './ComponentName.styles'
 import { ComponentNameProps } from './ComponentName.types'
 
 const ComponentName: FC<ComponentNameProps> = () => {
+	const styles = makeStyles()
 	return (
 		<div>
 			ComponentName

--- a/src/templates/stylesTemplate.ts
+++ b/src/templates/stylesTemplate.ts
@@ -1,6 +1,8 @@
 export default `import { ComponentNameStyles } from './ComponentName.types'
 
-export default (): ComponentNameStyles => ({
+const makeStyles = (): ComponentNameStyles => ({
 
 })
+
+export default makeStyles
 `


### PR DESCRIPTION
Inspired by a warning I got in another project where I shouldn't have an anonymous function as a default export. I changed this by creating a variable for it and then making it the default export.